### PR TITLE
switched to lon,lat ordering for geometry coords

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -95,7 +95,7 @@ export interface SharedStreetsGeometry {
   roadClass?: RoadClass;
 
   /** SharedStreetsGeometry latlons */
-  latlons?: number[];
+  lonlats?: number[];
 }
 
 /** Properties of a LocationReference. */


### PR DESCRIPTION
@DenisCarriere made switch to lon,lat ordering for geometries as part of latest round of revisions to pbf format